### PR TITLE
Removed 4096 insertions of EnderStorage EnderChest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,10 +60,24 @@ configFile.withReader {
     project.ext.config = new ConfigSlurper().parse prop
 }
 
+repositories {
+    maven {
+        name = "gt"
+        url = "https://gregtech.overminddl1.com/"
+    }
+    maven {
+        name = "chickenbones"
+        url = "https://nexus.covers1624.net/repository/maven-hosted/"
+    }
+}
+
 dependencies {
     // I dont have to specify NEI.. because gradle magic. aka: transitive dependency resolution
     compile "mcp.mobius.waila:Waila:1.5.7a_1.7.10"
     deployerJars "org.apache.maven.wagon:wagon-ssh:2.2"
+
+    compile "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
+    compile "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
 }
 
 minecraft {

--- a/src/main/java/mcp/mobius/betterbarrels/RecipeHandler.java
+++ b/src/main/java/mcp/mobius/betterbarrels/RecipeHandler.java
@@ -30,9 +30,7 @@ public class RecipeHandler {
 
 		Block CBEnderChest = Block.getBlockFromName("EnderStorage:enderChest");
 		if (CBEnderChest != null) {
-			for (int meta=0; meta < 4096; meta++) {
-				OreDictionary.registerOre("transdimBlock", new ItemStack(CBEnderChest, 1, meta));
-			}
+			OreDictionary.registerOre("transdimBlock", new ItemStack(CBEnderChest, 1, OreDictionary.WILDCARD_VALUE));
 		}
 	}
 


### PR DESCRIPTION
So originally this loop was created because author wanted to add all Ender Chests from EnderStorage to the BSpace Recipe. He didn't do this with wildcard (as done now), because Ender Chest and Ender Tank share the same item, so the recipe didn't want to accept tanks (item with meta > 4096). 

But I changed it back to WILDCARD, because:
1) It speeds up the modpack loading by 6 seconds.
2) 4096 excess items were removed from OreDictionary.
3) The recipe was overriden in GTNH, so actually, the players won't notice any change.
4) Ender Tank has almost the same recipe, so why not to use it as well? (moreover, it allows to use vanilla EnderChest) 