### PR TITLE
Allow moving Forestry worktable with dolly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,13 @@ repositories {
             url = "https://jitpack.io"
         }
     }
+    maven {
+        name = "IC2 maven" // Forestry
+        url = "http://maven.ic2.player.to"
+        metadataSources {
+            artifact() // Needed due to missing .pom
+        }
+    }
 }
 
 dependencies {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,4 +3,6 @@
 dependencies {
     compile("com.github.GTNewHorizons:waila:master-SNAPSHOT:dev")
     compileOnly("curse.maven:minefactory-reloaded-66672:2366150")
+    compileOnly("net.sengir.forestry:forestry_1.7.10:4.2.9.57:dev")
+    compileOnly("com.mod-buildcraft:buildcraft:7.1.23:dev") // Needed by Forestry
 }


### PR DESCRIPTION
This allows moving or rotating the worktable without losing saved recipes.