### PR TITLE
Fix ores in a barrel looks white

### DIFF
--- a/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderer.java
+++ b/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderer.java
@@ -5,6 +5,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureManager;
@@ -141,6 +142,9 @@ public class SurfaceItemRenderer extends RenderItem {
 
     private void renderItemIntoGUIBlock(FontRenderer fontRenderer, TextureManager texManager, ItemStack itemStack,
             int x, int y, boolean renderEffect) {
+        RenderHelper.enableGUIStandardItemLighting();
+        GL11.glDisable(GL11.GL_LIGHTING);
+
         texManager.bindTexture(TextureMap.locationBlocksTexture);
         Block block = Block.getBlockFromItem(itemStack.getItem());
 
@@ -181,5 +185,7 @@ public class SurfaceItemRenderer extends RenderItem {
         if (block.getRenderBlockPass() == 0) GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
 
         GL11.glPopMatrix();
+
+        RenderHelper.disableStandardItemLighting();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15563

Ores and machines inside barrel is now displayed correctly regardless of view angle.
![スクリーンショット 2024-05-06 100014](https://github.com/GTNewHorizons/Jabba/assets/39122497/cc399322-f4fb-48a6-aa6d-71b5a05a5984)


![スクリーンショット 2024-05-06 100801](https://github.com/GTNewHorizons/Jabba/assets/39122497/129f3bf1-c850-490a-a262-7c2e2f730616)
