### PR TITLE
Config option to disable dolly stacking

### DIFF
--- a/src/main/java/mcp/mobius/betterbarrels/BetterBarrels.java
+++ b/src/main/java/mcp/mobius/betterbarrels/BetterBarrels.java
@@ -69,7 +69,7 @@ public class BetterBarrels {
 
     /* CONFIG PARAMS */
     private static Configuration config = null;
-
+    public static boolean DisableStacking;
     public static boolean fullBarrelTexture = true;
     public static boolean highRezTexture = true;
     public static boolean showUpgradeSymbols = true;
@@ -215,6 +215,8 @@ public class BetterBarrels {
                     Configuration.CATEGORY_GENERAL,
                     BlacklistedTileEntiyClassNames,
                     "The Canonical Class-Names of TileEntities that should be ignored when using a Dolly.");
+
+            DisableStacking = config.getBoolean("DisableStacking", Configuration.CATEGORY_GENERAL, false, "Disables the ability to collapse and stack the dollies");
 
             // fullBarrelTexture = config.get(Configuration.CATEGORY_GENERAL, "fullBarrelTexture",
             // true).getBoolean(true);

--- a/src/main/java/mcp/mobius/betterbarrels/BetterBarrels.java
+++ b/src/main/java/mcp/mobius/betterbarrels/BetterBarrels.java
@@ -69,7 +69,7 @@ public class BetterBarrels {
 
     /* CONFIG PARAMS */
     private static Configuration config = null;
-    public static boolean DisableStacking;
+    public static boolean disableDollyStacking;
     public static boolean fullBarrelTexture = true;
     public static boolean highRezTexture = true;
     public static boolean showUpgradeSymbols = true;
@@ -216,7 +216,11 @@ public class BetterBarrels {
                     BlacklistedTileEntiyClassNames,
                     "The Canonical Class-Names of TileEntities that should be ignored when using a Dolly.");
 
-            DisableStacking = config.getBoolean("DisableStacking", Configuration.CATEGORY_GENERAL, false, "Disables the ability to collapse and stack the dollies");
+            disableDollyStacking = config.getBoolean(
+                    "disableDollyStacking",
+                    Configuration.CATEGORY_GENERAL,
+                    false,
+                    "Disables the ability to collapse and stack the dollies");
 
             // fullBarrelTexture = config.get(Configuration.CATEGORY_GENERAL, "fullBarrelTexture",
             // true).getBoolean(true);

--- a/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
+++ b/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
@@ -187,7 +187,6 @@ public class ItemBarrelMover extends Item {
         return false;
     }
 
-
     @Override
     public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
         if (world.isRemote) {
@@ -195,7 +194,7 @@ public class ItemBarrelMover extends Item {
         }
 
         // Config to enable or disable Dollie
-        if (BetterBarrels.DisableStacking) {
+        if (BetterBarrels.disableDollyStacking) {
             return itemStack;
         }
 
@@ -204,7 +203,6 @@ public class ItemBarrelMover extends Item {
             itemStack.getTagCompound().removeTag(PREVENT_FOLD_TAG_KEY);
             return itemStack;
         }
-
 
         if (player.isSneaking() && type == DollyType.NORMAL
                 && (!itemStack.hasTagCompound() || !itemStack.getTagCompound().hasKey("Container"))) {
@@ -223,8 +221,6 @@ public class ItemBarrelMover extends Item {
 
         return itemStack;
     }
-
-
 
     protected boolean placeContainer(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side) {
         NBTTagCompound nbtStack = stack.getTagCompound();

--- a/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
+++ b/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
@@ -187,9 +187,15 @@ public class ItemBarrelMover extends Item {
         return false;
     }
 
+
     @Override
     public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
         if (world.isRemote) {
+            return itemStack;
+        }
+
+        // Config to enable or disable Dollie
+        if (BetterBarrels.DisableStacking) {
             return itemStack;
         }
 
@@ -198,6 +204,7 @@ public class ItemBarrelMover extends Item {
             itemStack.getTagCompound().removeTag(PREVENT_FOLD_TAG_KEY);
             return itemStack;
         }
+
 
         if (player.isSneaking() && type == DollyType.NORMAL
                 && (!itemStack.hasTagCompound() || !itemStack.getTagCompound().hasKey("Container"))) {
@@ -216,6 +223,8 @@ public class ItemBarrelMover extends Item {
 
         return itemStack;
     }
+
+
 
     protected boolean placeContainer(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side) {
         NBTTagCompound nbtStack = stack.getTagCompound();


### PR DESCRIPTION
It is disabled as default, dollies are way too powerful to carry so many dollies out on your adventures in my pack