### PR TITLE
Fix chest flickering when a barrel is in sight

### DIFF
--- a/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderHelper.java
+++ b/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderHelper.java
@@ -11,27 +11,20 @@ import org.lwjgl.opengl.GL11;
  */
 public class SurfaceItemRenderHelper {
 
-    private static FloatBuffer colorBuffer = GLAllocation.createDirectFloatBuffer(16);
-    private static FloatBuffer cachedLightSetting = GLAllocation.createDirectFloatBuffer(16);
+    private static final FloatBuffer ambientColorBuffer = (FloatBuffer) GLAllocation.createDirectFloatBuffer(16)
+            .put(0.4f).put(0.4f).put(0.4f).put(1.0f).flip();
+    private static final FloatBuffer cachedAmbientColor = GLAllocation.createDirectFloatBuffer(16);
 
     public static void disableStandardItemLighting() {
         GL11.glDisable(GL11.GL_COLOR_MATERIAL);
-        GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, cachedLightSetting);
+        GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, cachedAmbientColor);
     }
 
     public static void enableStandardItemLighting() {
         GL11.glEnable(GL11.GL_COLOR_MATERIAL);
         GL11.glColorMaterial(GL11.GL_FRONT_AND_BACK, GL11.GL_AMBIENT_AND_DIFFUSE);
-        float f = 0.4F;
         GL11.glShadeModel(GL11.GL_FLAT);
-        GL11.glGetFloat(GL11.GL_LIGHT_MODEL_AMBIENT, cachedLightSetting);
-        GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, setColorBuffer(f, f, f, 1.0F));
-    }
-
-    private static FloatBuffer setColorBuffer(float p_74521_0_, float p_74521_1_, float p_74521_2_, float p_74521_3_) {
-        colorBuffer.clear();
-        colorBuffer.put(p_74521_0_).put(p_74521_1_).put(p_74521_2_).put(p_74521_3_);
-        colorBuffer.flip();
-        return colorBuffer;
+        GL11.glGetFloat(GL11.GL_LIGHT_MODEL_AMBIENT, cachedAmbientColor);
+        GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, ambientColorBuffer);
     }
 }

--- a/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderHelper.java
+++ b/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderHelper.java
@@ -1,0 +1,37 @@
+package mcp.mobius.betterbarrels.client.render;
+
+import java.nio.FloatBuffer;
+
+import net.minecraft.client.renderer.GLAllocation;
+
+import org.lwjgl.opengl.GL11;
+
+/**
+ * RenderHelper but no directional light setting
+ */
+public class SurfaceItemRenderHelper {
+
+    private static FloatBuffer colorBuffer = GLAllocation.createDirectFloatBuffer(16);
+    private static FloatBuffer cachedLightSetting = GLAllocation.createDirectFloatBuffer(16);
+
+    public static void disableStandardItemLighting() {
+        GL11.glDisable(GL11.GL_COLOR_MATERIAL);
+        GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, cachedLightSetting);
+    }
+
+    public static void enableStandardItemLighting() {
+        GL11.glEnable(GL11.GL_COLOR_MATERIAL);
+        GL11.glColorMaterial(GL11.GL_FRONT_AND_BACK, GL11.GL_AMBIENT_AND_DIFFUSE);
+        float f = 0.4F;
+        GL11.glShadeModel(GL11.GL_FLAT);
+        GL11.glGetFloat(GL11.GL_LIGHT_MODEL_AMBIENT, cachedLightSetting);
+        GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, setColorBuffer(f, f, f, 1.0F));
+    }
+
+    private static FloatBuffer setColorBuffer(float p_74521_0_, float p_74521_1_, float p_74521_2_, float p_74521_3_) {
+        colorBuffer.clear();
+        colorBuffer.put(p_74521_0_).put(p_74521_1_).put(p_74521_2_).put(p_74521_3_);
+        colorBuffer.flip();
+        return colorBuffer;
+    }
+}

--- a/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderer.java
+++ b/src/main/java/mcp/mobius/betterbarrels/client/render/SurfaceItemRenderer.java
@@ -5,7 +5,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureManager;
@@ -142,7 +141,7 @@ public class SurfaceItemRenderer extends RenderItem {
 
     private void renderItemIntoGUIBlock(FontRenderer fontRenderer, TextureManager texManager, ItemStack itemStack,
             int x, int y, boolean renderEffect) {
-        RenderHelper.enableGUIStandardItemLighting();
+        SurfaceItemRenderHelper.enableStandardItemLighting();
         GL11.glDisable(GL11.GL_LIGHTING);
 
         texManager.bindTexture(TextureMap.locationBlocksTexture);
@@ -186,6 +185,6 @@ public class SurfaceItemRenderer extends RenderItem {
 
         GL11.glPopMatrix();
 
-        RenderHelper.disableStandardItemLighting();
+        SurfaceItemRenderHelper.disableStandardItemLighting();
     }
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16410

We must use vanilla enableStandardItemLighting() to render GT ores correctly.
However, Vanilla enableStandardItemLighting() leaks directional light setting and ambient light setting to other blocks when Angelica's GLStateCaching is enabled.
To fight against this I wrote enableStandardItemLighting() without unused directional light setting, and cached ambient light setting in the new method to prevent leakage.