### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/jabba/lang/en_US.lang
+++ b/src/main/resources/assets/jabba/lang/en_US.lang
@@ -1,3 +1,4 @@
+item.upgrade.core.generic.name=Storage upgrade
 item.upgrade.core.storage.name=Storage upgrade
 item.upgrade.core.storage3.name=Storage upgrade x3
 item.upgrade.core.storage9.name=Storage upgrade x9
@@ -20,12 +21,15 @@ text.jabba.ubgrade.core.storage=Increases the storage capacity by %s stacks
 text.jabba.ubgrade.core.void=Deletes excess added items once the barrel is full.
 text.jabba.ubgrade.core.creative=Allows for infinite withdrawals from a barrel.
 
+item.upgrade.side.generic.name=Sticker / Facade
 item.upgrade.side.sticker.name=Sticker
 item.upgrade.side.hopper.name=Hopper facade
 item.upgrade.side.redstone.name=Redstone facade
 
+item.item.upgrade.structural.generic.name=Structural
 item.upgrade.structural=Structural MK
 
+item.hammer.name=Barrel Hammer
 item.hammer.normal.name=Barrel Hammer
 item.hammer.bspace.name=Barrel Hammer(Resonating)
 item.hammer.redstone.name=Barrel Hammer(Redstone)


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.