### PR TITLE
Add Binnie's Mods Compartments Support to Dolly

### DIFF
--- a/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
+++ b/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
@@ -121,6 +121,8 @@ public class ItemBarrelMover extends Item {
 
         classExtensionsNames.add("ganymedes01.etfuturum.tileentities.TileEntityBarrel");
 
+        classExtensionsNames.add("binnie.core.machines.TileEntityMachine");
+
         for (String s : classExtensionsNames) {
             try {
                 classExtensions.add(Class.forName(s));


### PR DESCRIPTION
## What's Changed

This PR adds support for moving Binnie's Mods Compartments using JABBA's Dolly.

### Add Binnie's Mods Compartments Support to Dolly

- Add binnie.core.machines.TileEntityMachine to Dolly's supported container list
- Enables moving all Binnie's Compartments variants (Basic/Copper/Bronze/Iron/Gold/Diamond)
- No special orientation handling required (compartments are directionless)
- Gracefully handles when Binnie's Mods is not installed

All Binnie's Compartments use TileEntityMachine as their TileEntity class,
which properly implements NBT serialization for complete state preservation.
This allows players to relocate Binnie's storage containers with the same
convenience as other supported containers like chests and barrels.

**Files changed:**

- Modified `ItemBarrelMover.java` - Added Binnie's TileEntityMachine to classExtensionsNames list

## Testing
- [x] Code compiles successfully
- [x] Spotless formatting passes
- [x] Tested in-game

## Screenshots

https://github.com/user-attachments/assets/05059ac6-0226-4b8c-9553-7c361d8a12b0



<br>
<br>

---
- Closes GTNewHorizons/GT-New-Horizons-Modpack#21962