### PR TITLE
Allow compressed (and infinity) chests to be dollied.

### DIFF
--- a/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
+++ b/src/main/java/mcp/mobius/betterbarrels/common/items/dolly/ItemBarrelMover.java
@@ -121,6 +121,8 @@ public class ItemBarrelMover extends Item {
 
         classExtensionsNames.add("ganymedes01.etfuturum.tileentities.TileEntityBarrel");
 
+        classExtensionsNames.add("wanion.avaritiaddons.block.chest.TileEntityAvaritiaddonsChest");
+
         for (String s : classExtensionsNames) {
             try {
                 classExtensions.add(Class.forName(s));


### PR DESCRIPTION
Although it isn't necessary to use a dolly with the compressed chest, given that it keeps its contents, I somtimes find it more convenient to use a dolly to move them. In particular, with a dolly, you don't need to switch hotbar slots top pickup and then place a chest.